### PR TITLE
Accept custom callback function in opts constructor for missing keys

### DIFF
--- a/lib/kama.js
+++ b/lib/kama.js
@@ -85,10 +85,10 @@ Kama.prototype.configure = function(files, opts) {
 		} else if (opts.missingKeyCallback) {
 			this.missingKeyCallback = opts.missingKeyCallback;
 		}
+	}
 
-		if(opts.defaultLocale) {
-			this.defaultLocale = opts.defaultLocale;
-		}
+	if(opts.defaultLocale) {
+		this.defaultLocale = opts.defaultLocale;
 	}
 
 	return this;

--- a/lib/kama.js
+++ b/lib/kama.js
@@ -107,7 +107,7 @@ Kama.prototype.translate = function(key, params, locale) {
 		}
 	}
 
-	// return the key if a translation is missing. this seems less rude than just throwing an error.
+	// return the key if a translation is missing or use the passed callback function
 	return str ? this.env.renderString(str, params) : this.missingKeyCallback(key);
 };
 

--- a/lib/kama.js
+++ b/lib/kama.js
@@ -52,6 +52,10 @@ Kama.prototype.keys = [];
 
 Kama.prototype.defaultLocale = 'en_US';
 
+Kama.prototype.missingKeyCallback = function(key) {
+	return key;
+}
+
 Kama.prototype.configure = function(files, opts) {
 	var filePaths,
 		cwd;
@@ -73,11 +77,13 @@ Kama.prototype.configure = function(files, opts) {
 	}
 
 	if(opts) {
-		// if an environment is passed, ignore tag overrides
+		// if an environment is passed, ignores tag overrides
 		if(opts.env) {
 			this.env = opts.env;
 		} else if(opts.tags) {
 			this.env = new nunjucks.Environment(null, {tags: opts.tags});
+		} else if (opts.missingKeyCallback) {
+			this.missingKeyCallback = opts.missingKeyCallback;
 		}
 
 		if(opts.defaultLocale) {
@@ -93,7 +99,7 @@ Kama.prototype.translate = function(key, params, locale) {
 		res,
 		str;
 
-	// cascade through res bundles via file:key:locale > file:key:defaultLocale
+	// casacade through res bundles via file:key:locale > file:key:defaultLocale
 	while(!str && len--) {
 		res = this.keys[len][key];
 		if(res) {
@@ -102,7 +108,7 @@ Kama.prototype.translate = function(key, params, locale) {
 	}
 
 	// return the key if a translation is missing. this seems less rude than just throwing an error.
-	return str ? this.env.renderString(str, params) : key;
+	return str ? this.env.renderString(str, params) : this.missingKeyCallback(key);
 };
 
 module.exports = new Kama();

--- a/lib/kama.js
+++ b/lib/kama.js
@@ -77,7 +77,7 @@ Kama.prototype.configure = function(files, opts) {
 	}
 
 	if(opts) {
-		// if an environment is passed, ignores tag overrides
+		// if an environment is passed, ignore tag overrides
 		if(opts.env) {
 			this.env = opts.env;
 		} else if(opts.tags) {
@@ -99,7 +99,7 @@ Kama.prototype.translate = function(key, params, locale) {
 		res,
 		str;
 
-	// casacade through res bundles via file:key:locale > file:key:defaultLocale
+	// cascade through res bundles via file:key:locale > file:key:defaultLocale
 	while(!str && len--) {
 		res = this.keys[len][key];
 		if(res) {

--- a/test/test-kama.js
+++ b/test/test-kama.js
@@ -41,6 +41,13 @@ describe('Kama', function() {
 		expect(kama.translate('hello_params', params, FR_FR)).to.be('Bonjour, Blah');
 	});
 
+	it('should return passed key on missing key', function() {
+		var custom = new kama.Kama(
+			file1
+		);
+		expect(custom.translate('___nonexistent', params)).to.be('___nonexistent');
+	});
+
 	describe('#constructor', function() {
 
 		it('should create a seperate instance', function() {
@@ -58,6 +65,18 @@ describe('Kama', function() {
 				{tags: {variableStart: '${', variableEnd: '}'}
 			});
 			expect(custom.translate('hello_custom_params', params)).to.be('Hello, Blah');
+		});
+
+		it('should accept custom missingKeyCallback function', function() {
+			var custom = new kama.Kama(
+				file1,
+				{
+					missingKeyCallback: function(key) {
+						return 'test it works';
+					}
+				}
+			);
+			expect(custom.translate('___nonexistent', params)).to.be('test it works');
 		});
 
 		it('should accept a custom nunjucks environment', function() {


### PR DESCRIPTION
Updated to allow a custom callback function to be passed in the constructors opts for use when the requested key cannot be found.

Added unit tests as well.
